### PR TITLE
Fix args typo in zerossl-bot.sh

### DIFF
--- a/zerossl-bot.sh
+++ b/zerossl-bot.sh
@@ -38,4 +38,4 @@ elif [[ -n $ZEROSSL_EMAIL ]]; then
     parse_eab_credentials $(curl -s https://api.zerossl.com/acme/eab-credentials-email --data "email=$ZEROSSL_EMAIL")
 fi
 
-certbot ${ARGS[@]}
+certbot ${CERTBOT_ARGS[@]}


### PR DESCRIPTION
Bug: no args are passed to `certbot`