### PR TITLE
Don't run curl as root

### DIFF
--- a/get-zerosslbot.sh
+++ b/get-zerosslbot.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 
 
-ZEROSSLBOT_SCRIPT_LOCATION=${ZEROSSLBOT_SCRIPT_LOCATION-"https://zerossl.com/zerossl-bot.sh"}
+ZEROSSLBOT_SCRIPT_LOCATION=${ZEROSSLBOT_SCRIPT_LOCATION:-"https://zerossl.com/zerossl-bot.sh"}
 
-function install_zerosslbot()
+function install_zerosslbot
 {
+    curl -s "$ZEROSSLBOT_SCRIPT_LOCATION" > /tmp/zerossl-bot && \
     sudo bash <<EOF
-        curl -s "$ZEROSSLBOT_SCRIPT_LOCATION" > /tmp/zerossl-bot && \
-        mkdir -p /usr/local/bin
+        mkdir -p /usr/local/bin && \
         mv /tmp/zerossl-bot /usr/local/bin/zerossl-bot && \
         chmod +x /usr/local/bin/zerossl-bot
 EOF


### PR DESCRIPTION
There's no particularly good reason to run the curl as root, so move that out of the sudo block.

Also switch the `-` to `:-` in script location; the former only applies if the variable is undefined, while the latter also applies if the variable is defined but empty.  It's unlikely that anyone actually wants an empty location directory to cause a weird curl error. :)

And delete the vestigial `()` after the function name while I'm in there, as well as adding an `&&` after the mkdir -- which also returns true if the directory also exists.