### PR TITLE
Fix issue with params ignoring by certbot.

### DIFF
--- a/zerossl-bot.sh
+++ b/zerossl-bot.sh
@@ -38,4 +38,4 @@ elif [[ -n $ZEROSSL_EMAIL ]]; then
     parse_eab_credentials $(curl -s https://api.zerossl.com/acme/eab-credentials-email --data "email=$ZEROSSL_EMAIL")
 fi
 
-certbot ${ARGS[@]}
+certbot ${CERTBOT_ARGS[@]}


### PR DESCRIPTION
Older version not working on `bash --version`: `5.1.8(0)-release (amd64-portbld-freebsd12.2)`