### PR TITLE
Fix argument processing so certbot is actually called correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,10 @@ Installation
 1. Install the operating system packages for `curl` and `certbot` 
 2. Install the ZeroSSL wrapper script
    1. Quick: 
-      1. run `bash <(curl -s https://zerossl.com/get-zerosslbot.sh)`
+      1. run `bash <(curl -s https://raw.githubusercontent.com/digitalsparky/zerossl-bot/master/get-zerosslbot.sh)`
       2. Done!
    2. Careful: 
-      1. Run `curl -s https://zerossl.com/get-zerosslbot.sh > get-zerosslbot.sh`
+      1. Run `curl -s https://raw.githubusercontent.com/digitalsparky/zerossl-bot/master/get-zerosslbot.sh > get-zerosslbot.sh`
       2. Inspect the file to see that it does what it is supposed to do
       3. Run `source get-zerosslbot.sh`
       

--- a/get-zerosslbot.sh
+++ b/get-zerosslbot.sh
@@ -5,9 +5,9 @@ ZEROSSLBOT_SCRIPT_LOCATION=${ZEROSSLBOT_SCRIPT_LOCATION-"https://raw.githubuserc
 
 function install_zerosslbot()
 {
+    curl -s "$ZEROSSLBOT_SCRIPT_LOCATION" > /tmp/zerossl-bot
     sudo bash <<EOF
-        curl -s "$ZEROSSLBOT_SCRIPT_LOCATION" > /tmp/zerossl-bot && \
-        mkdir -p /usr/local/bin
+        mkdir -p /usr/local/bin && \
         mv /tmp/zerossl-bot /usr/local/bin/zerossl-bot && \
         chmod +x /usr/local/bin/zerossl-bot
 EOF

--- a/get-zerosslbot.sh
+++ b/get-zerosslbot.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 
-ZEROSSLBOT_SCRIPT_LOCATION=${ZEROSSLBOT_SCRIPT_LOCATION-"https://zerossl.com/zerossl-bot.sh"}
+ZEROSSLBOT_SCRIPT_LOCATION=${ZEROSSLBOT_SCRIPT_LOCATION-"https://raw.githubusercontent.com/digitalsparky/zerossl-bot/master/zerossl-bot.sh"}
 
 function install_zerosslbot()
 {

--- a/zerossl-bot.sh
+++ b/zerossl-bot.sh
@@ -32,10 +32,12 @@ while [[ "$#" -gt 0 ]]; do
     shift
 done
 
+set -- "${CERTBOT_ARGS[@]}"
+
 if [[ -n $ZEROSSL_API_KEY ]]; then
     parse_eab_credentials $(curl -s -X POST "https://api.zerossl.com/acme/eab-credentials?access_key=$ZEROSSL_API_KEY")
 elif [[ -n $ZEROSSL_EMAIL ]]; then
     parse_eab_credentials $(curl -s https://api.zerossl.com/acme/eab-credentials-email --data "email=$ZEROSSL_EMAIL")
 fi
 
-certbot ${ARGS[@]}
+certbot ${CERTBOT_ARGS[@]}


### PR DESCRIPTION
The existing script was evaluating the certbot call with no arguments.
This patch fixes argument processing and updates the certbot command to use the relevant arguments.