### PR TITLE
fixed arg parse with quoted strings and authentication hooks

### DIFF
--- a/zerossl-bot.sh
+++ b/zerossl-bot.sh
@@ -27,7 +27,7 @@ while [[ "$#" -gt 0 ]]; do
            CERTBOT_ARGS+=(-m "${2}")
            shift
         ;;
-        *) CERTBOT_ARGS+=($1) ;;
+        *) CERTBOT_ARGS+=("$1") ;;
     esac
     shift
 done
@@ -38,4 +38,4 @@ elif [[ -n $ZEROSSL_EMAIL ]]; then
     parse_eab_credentials $(curl -s https://api.zerossl.com/acme/eab-credentials-email --data "email=$ZEROSSL_EMAIL")
 fi
 
-certbot ${CERTBOT_ARGS[@]}
+certbot "${CERTBOT_ARGS[@]}"


### PR DESCRIPTION
# Rationale

While there [are others](https://github.com/zerossl/zerossl-bot/pull/16) that also made a fix, these still fail in some cases. For example, something like `zerossl-bot "cercertonly --csr=csr.txt --config-dir=certbot/config --logs-dir=certbot/logs --work-dir=certbot/work --manual --agree-tos --email=email@example.com -n --manual-public-ip-logging-ok --preferred-challenges=dns --manual-auth-hook=my_hook_script argument1 argument2` still fails, as the software doesn't parse quoted arguments correctly, whereas raw `certbot` parses this fine.

Therefore, I propose to add quotes in the argument parser and where we forward it back to `certbot`, it succeeded in all cases I threw at it.